### PR TITLE
Auto docker

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,55 @@
+name: Build and Push Docker Image
+
+on:
+  release:
+    types: [published]
+
+env:
+  DOCKER_HUB_USERNAME: eholk
+  IMAGE_NAME: eholk/ebg
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
+
+      - name: Get release version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -58,3 +58,50 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      
+      # New steps to update Dockerfile in the version bump PR
+      - name: Extract new version from Cargo.toml
+        id: extract_version
+        run: |
+          NEW_VERSION=$(grep -m 1 '^version = ' Cargo.toml | sed 's/^version = "\(.*\)"$/\1/')
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "Extracted version: $NEW_VERSION"
+      
+      - name: Extract Rust version from rust-toolchain.toml
+        id: rust_version
+        run: |
+          RUST_CHANNEL=$(grep -oP 'channel\s*=\s*"\K[^"]+' rust-toolchain.toml)
+          echo "RUST_CHANNEL=$RUST_CHANNEL" >> $GITHUB_ENV
+          echo "Rust channel: $RUST_CHANNEL"
+      
+      - name: Update Dockerfile with new versions
+        run: |
+          # Create a new Dockerfile with updated version info
+          cat > Dockerfile.new << EOF
+          FROM rust:${RUST_CHANNEL}
+
+          # Run rustup update so we pick up the toolchain version in rust-toolchain.toml
+          RUN cargo install ebg --version ${NEW_VERSION}
+          EOF
+
+          # Replace the original Dockerfile
+          mv Dockerfile.new Dockerfile
+          
+          # Show the updated Dockerfile
+          cat Dockerfile
+      
+      - name: Commit updated Dockerfile to release PR branch
+        run: |
+          # The PR branch created by release-plz follows the pattern "release-plz/bump-<version>"
+          PR_BRANCH=$(git branch -r | grep "origin/release-plz/bump" | sed 's/origin\///' | head -n 1)
+          
+          if [ -n "$PR_BRANCH" ]; then
+            git config --local user.email "github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+            git add Dockerfile
+            git commit -m "Update Dockerfile for version ${NEW_VERSION}"
+            git push origin HEAD:$PR_BRANCH
+            echo "Updated Dockerfile in $PR_BRANCH"
+          else
+            echo "No release-plz PR branch found"
+          fi

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -64,7 +64,10 @@ jobs:
         id: extract_version
         run: |
           NEW_VERSION=$(grep -m 1 '^version = ' Cargo.toml | sed 's/^version = "\(.*\)"$/\1/')
-          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          if [ -z "$NEW_VERSION" ]; then
+            echo "Error: Failed to extract version from Cargo.toml. Ensure the file contains a valid 'version' line." >&2
+            exit 1
+          fi
           echo "Extracted version: $NEW_VERSION"
       
       - name: Extract Rust version from rust-toolchain.toml


### PR DESCRIPTION
In theory, this updates the release-plz release PR to also bump the versions in the Dockerfile. Then it adds an action to automatically release the Docker image when I do a new code release.

This was mostly written by Copilot, so who knows if it works? Unfortunately, with actions the only option really is to do spooky debugging at a distance.